### PR TITLE
Improve input handling and README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 🤗 <a href="https://huggingface.co/Alibaba-NLP/Tongyi-DeepResearch-30B-A3B" target="_blank">HuggingFace</a> ｜
 <img src="./assets/tongyi.png" width="14px" style="display:inline;"> <a href="https://modelscope.cn/models/iic/Tongyi-DeepResearch-30B-A3B" target="_blank">ModelScope</a>
 <p align="center">
-<a href="https://trendshift.io/repositories/14217" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14217" 
+<a href="https://trendshift.io/repositories/14217" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14217"
 alt="Alibaba-NLP%2FWebAgent | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 # Introduction
@@ -66,7 +66,7 @@ This guide provides instructions for setting up the environment and running infe
 
 ```bash
 # Example with Conda
-conda create -n react_infer_env python=3.10.0 
+conda create -n react_infer_env python=3.10.0
 conda activate react_infer_env
 ```
 
@@ -78,19 +78,50 @@ pip install -r requirements.txt
 ```
 
 ### 3. Prepare Evaluation Data
-- Create a folder named `eval_data/` in the project root.
-- Place your QA file in **JSONL** format inside this directory, e.g. `eval_data/example.jsonl`.
-- Each line must be a JSON object that includes **both** of the following keys:
+
+The system supports two input file formats: **JSON** and **JSONL**.
+
+#### Supported File Formats:
+
+**Option 1: JSONL Format (recommended)**
+- Create your data file with `.jsonl` extension (e.g., `my_questions.jsonl`)
+- Each line must be a valid JSON object with `question` and `answer` keys:
   ```json
-  {"question": "...","answer": "..."}
+  {"question": "What is the capital of France?", "answer": "Paris"}
+  {"question": "Explain quantum computing", "answer": ""}
   ```
-- A sample file is provided in the `eval_data` folder for reference.
-- If you plan to use the *file parser* tool, **prepend the file name to the `question` field** and place the referenced file inside the `eval_data/file_corpus/` directory.
+
+**Option 2: JSON Format**
+- Create your data file with `.json` extension (e.g., `my_questions.json`)
+- File must contain a JSON array of objects, each with `question` and `answer` keys:
+  ```json
+  [
+    {"question": "What is the capital of France?", "answer": "Paris"},
+    {"question": "Explain quantum computing", "answer": ""}
+  ]
+  ```
+
+**Important Note:** The `answer` field contains the **ground truth/reference answer** used for evaluation. The system generates its own responses to the questions, and these reference answers are used to automatically judge the quality of the generated responses during benchmark evaluation.
+
+#### File References for Document Processing:
+- If using the *file parser* tool, **prepend the filename to the `question` field**
+- Place referenced files in `eval_data/file_corpus/` directory
+- Example: `{"question": "report.pdf What are the key findings?", "answer": "..."}`
+
+#### File Organization:
+```
+project_root/
+├── eval_data/
+│   ├── my_questions.jsonl          # Your evaluation data
+│   └── file_corpus/                # Referenced documents
+│       ├── report.pdf
+│       └── data.xlsx
+```
 
 ### 4. Configure the Inference Script
 - Open `run_react_infer.sh` and modify the following variables as instructed in the comments:
   * `MODEL_PATH`  - path to the local or remote model weights.
-  * `DATASET`     - path to the evaluation set, e.g. `example`.
+  * `DATASET`     - full path to your evaluation file, e.g. `eval_data/my_questions.jsonl` or `/path/to/my_questions.json`.
   * `OUTPUT_PATH` - path for saving the prediction results, e.g. `./outputs`.
 - Depending on the tools you enable (retrieval, calculator, web search, etc.), provide the required `API_KEY`, `BASE_URL`, or other credentials. Each key is explained inline in the bash script.
 

--- a/inference/run_multi_react.py
+++ b/inference/run_multi_react.py
@@ -36,19 +36,19 @@ if __name__ == "__main__":
         exit(1)
 
     model_name = os.path.basename(model.rstrip('/'))
-    
+
     model_dir = os.path.join(output_base, f"{model_name}_sglang")
     dataset_dir = os.path.join(model_dir, args.dataset)
- 
+
     os.makedirs(dataset_dir, exist_ok=True)
-    
+
     print(f"Model name: {model_name}")
-    print(f"Data set name: {args.dataset}")
+    print(f"Data set path: {args.dataset}")
     print(f"Output directory: {dataset_dir}")
     print(f"Number of rollouts: {roll_out_count}")
     print(f"Data splitting: {worker_split}/{total_splits}")
 
-    data_filepath = f"eval_data/{args.dataset}.jsonl"
+    data_filepath = f"{args.dataset}"
     try:
         if data_filepath.endswith(".json"):
             with open(data_filepath, "r", encoding="utf-8") as f:
@@ -75,10 +75,10 @@ if __name__ == "__main__":
     items_per_split = math.ceil(total_items / total_splits)
     start_idx = (worker_split - 1) * items_per_split
     end_idx = min(worker_split * items_per_split, total_items)
-    
+
     # Split the dataset
     items = items[start_idx:end_idx]
-    
+
     print(f"Total items in dataset: {total_items}")
     print(f"Processing items {start_idx} to {end_idx-1} ({len(items)} items)")
 
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         output_files = {i: os.path.join(dataset_dir, f"iter{i}_split{worker_split}of{total_splits}.jsonl") for i in range(1, roll_out_count + 1)}
     else:
         output_files = {i: os.path.join(dataset_dir, f"iter{i}.jsonl") for i in range(1, roll_out_count + 1)}
-    
+
     processed_queries_per_rollout = {}
 
     for rollout_idx in range(1, roll_out_count + 1):


### PR DESCRIPTION
This PR improves input handling and removes hardcoded: `eval_data/{arg}.jsonl`. Looking at the block below this code, this is actually blocking the ability to properly use `json` extension. I also improved the README.md becuase it was hard to understand myself when trying to run the project for this firs time. 

closes https://github.com/Alibaba-NLP/DeepResearch/issues/108