### PR TITLE
Add Tavily option for `deepresearch-inference`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ MAX_WORKERS=30
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
 
+# Tavily API for web search (alternative to Serper)
+# Get your key from: https://app.tavily.com/
+TAVILY_API_KEY=your_key
+
+# Search provider selection: "serper" (default) or "tavily"
+SEARCH_PROVIDER=serper
+
 # Jina API for web page reading
 # Get your key from: https://jina.ai/
 JINA_API_KEYS=your_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,6 +159,7 @@ soxr==1.0.0
 starlette==0.47.3
 sympy==1.14.0
 tabulate==0.9.0
+tavily-python>=0.5.0
 tenacity==9.1.2
 tiktoken==0.11.0
 tokenizers==0.22.0


### PR DESCRIPTION
## Search Provider Migration: `deepresearch-inference`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

## Migration Summary — `deepresearch-inference`

**Strategy**: ADDITIVE (Tavily added as parallel option; Serper fully preserved)

### Files Modified

1. **`inference/tool_search.py`**
   - Added `from tavily import TavilyClient` import
   - Added `SEARCH_PROVIDER` env var (defaults to `"serper"`)
   - Added `search_with_tavily()` method — uses `TavilyClient().search()` with `max_results=10`, formats results to match the existing snippet string format (numbered markdown links with dates)
   - Added `_do_search()` routing method — delegates to Tavily or Serper based on `SEARCH_PROVIDER`
   - Updated `call()` to use `_do_search()` instead of calling `search_with_serp()` directly

2. **`inference/tool_scholar.py`**
   - Added `from tavily import TavilyClient` import
   - Added `SEARCH_PROVIDER` env var (defaults to `"serper"`)
   - Added `scholar_with_tavily()` method — uses `TavilyClient().search()` with `search_depth="advanced"` and `include_domains` filtered to academic sources (arxiv.org, pubmed, semanticscholar, ieee, acm, springer, sciencedirect, nature, wiley)
   - Added `_do_scholar_search()` routing method
   - Updated `call()` to use `_do_scholar_search()` instead of calling `google_scholar_with_serp()` directly

3. **`requirements.txt`**
   - Added `tavily-python>=0.5.0` (alphabetical placement between `tabulate` and `tenacity`)

4. **`.env.example`**
   - Added `TAVILY_API_KEY=your_key` with comment linking to https://app.tavily.com/
   - Added `SEARCH_PROVIDER=serper` with comment explaining the `"tavily"` option

### How to Switch Providers

Set `SEARCH_PROVIDER=tavily` and provide `TAVILY_API_KEY` in your environment. The default remains `serper` so existing deployments are unaffected.
