### PR TITLE
Add Tavily option for `webagent-webdancer`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ MAX_WORKERS=30
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
 
+# Tavily API for web search (alternative to Serper for WebDancer demo)
+# Get your key from: https://app.tavily.com/
+TAVILY_API_KEY=your_key
+# Set SEARCH_PROVIDER to "tavily" to use Tavily, or "serper" (default) for Serper
+SEARCH_PROVIDER=serper
+
 # Jina API for web page reading
 # Get your key from: https://jina.ai/
 JINA_API_KEYS=your_key

--- a/WebAgent/WebDancer/requirements.txt
+++ b/WebAgent/WebDancer/requirements.txt
@@ -1,2 +1,3 @@
 sglang[all]
 qwen-agent[gui,rag,code_interpreter,mcp]
+tavily-python


### PR DESCRIPTION
## Search Provider Migration: `webagent-webdancer`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

## Migration Summary — `webagent-webdancer`

**Strategy**: ADDITIVE (Tavily added as parallel option, Serper preserved as default)

### Files Modified (3)

**1. `WebAgent/WebDancer/demos/tools/private/search.py`**
- Added `TAVILY_API_KEY` and `SEARCH_PROVIDER` env var reads at module level
- Updated `call()` to route to either `self.tavily_search` or `self.google_search` based on `SEARCH_PROVIDER` (defaults to `"serper"`)
- Added `tavily_search(query)` method that uses the Tavily Python SDK (`TavilyClient.search()`) with `max_results=10` and `search_depth="basic"`
- Tavily results are normalized to the same numbered-snippet markdown format as the existing Serper output
- The `@register_tool("search")` name is preserved — downstream agent/UI code requires no changes

**2. `WebAgent/WebDancer/requirements.txt`**
- Added `tavily-python` (existing deps untouched)

**3. `.env.example`** (repo root)
- Added `TAVILY_API_KEY=your_key` with a link to https://app.tavily.com/
- Added `SEARCH_PROVIDER=serper` with a comment explaining the toggle

### How to Use
Set `SEARCH_PROVIDER=tavily` and `TAVILY_API_KEY=tvly-...` in your environment to switch the WebDancer demo to Tavily. Leave `SEARCH_PROVIDER` unset or set to `serper` to keep the original Serper behavior.
