### PR TITLE
Add Tavily option for `webagent-webresummer`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ MAX_WORKERS=30
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
 
+# Tavily API for web search (alternative to Serper)
+# Get your key from: https://app.tavily.com/
+# Set SEARCH_PROVIDER=tavily to use Tavily instead of Serper
+TAVILY_API_KEY=your_key
+SEARCH_PROVIDER=serper
+
 # Jina API for web page reading
 # Get your key from: https://jina.ai/
 JINA_API_KEYS=your_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,6 +159,7 @@ soxr==1.0.0
 starlette==0.47.3
 sympy==1.14.0
 tabulate==0.9.0
+tavily-python>=0.5.0
 tenacity==9.1.2
 tiktoken==0.11.0
 tokenizers==0.22.0


### PR DESCRIPTION
## Search Provider Migration: `webagent-webresummer`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

Everything looks correct. Here's a summary of all changes made:

## Summary of Changes

### Strategy: ADDITIVE (parallel option)

**3 files modified** — all within the `DeepResearch` workspace:

### 1. `WebAgent/WebResummer/src/tool_search.py`
- **Added env vars** at module level: `TAVILY_API_KEY` and `SEARCH_PROVIDER` (defaults to `"serper"`)
- **Added `tavily_search()` method** that mirrors `google_search()` — uses `TavilyClient.search()` with `max_results=10`, same retry logic (5 attempts), and normalizes Tavily results (`title`, `url`, `content`, `published_date`) into the same numbered snippet format the rest of the agent expects
- **Updated `call()` method** to route between `tavily_search` and `google_search` based on the `SEARCH_PROVIDER` env var, with the appropriate API key assertion for each path
- **Preserved** all existing Serper/Google search code untouched

### 2. `requirements.txt` (root)
- **Added** `tavily-python>=0.5.0` (alphabetically between `tabulate` and `tenacity`)
- Existing dependencies untouched

### 3. `.env.example`
- **Added** `TAVILY_API_KEY=your_key` and `SEARCH_PROVIDER=serper` with descriptive comments, right below the existing Serper key section
- Existing env vars untouched

### How to use
Set `SEARCH_PROVIDER=tavily` and provide `TAVILY_API_KEY` to switch WebResummer to Tavily. The default (`serper`) keeps existing behavior unchanged.
