### PR TITLE
Add Tavily option for `webagent-websailor`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,16 @@ MAX_WORKERS=30
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
 
+# Google Search key used by WebSailor (Serper API)
+GOOGLE_SEARCH_KEY=your_key
+
+# Tavily API for web search (alternative to Serper in WebSailor)
+# Get your key from: https://app.tavily.com
+TAVILY_API_KEY=your_key
+
+# Search provider selection for WebSailor: "serper" (default) or "tavily"
+SEARCH_PROVIDER=serper
+
 # Jina API for web page reading
 # Get your key from: https://jina.ai/
 JINA_API_KEYS=your_key

--- a/WebAgent/WebSailor/requirements.txt
+++ b/WebAgent/WebSailor/requirements.txt
@@ -1,2 +1,3 @@
 sglang[all]
 qwen-agent[gui,rag,code_interpreter,mcp]
+tavily-python

--- a/WebAgent/WebSailor/src/tool_search.py
+++ b/WebAgent/WebSailor/src/tool_search.py
@@ -1,4 +1,4 @@
-from qwen_agent.tools.base import BaseTool, register_tool 
+from qwen_agent.tools.base import BaseTool, register_tool
 import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Union
@@ -8,6 +8,8 @@ import os
 
 SEARCH_API_URL = os.getenv("SEARCH_API_URL")
 GOOGLE_SEARCH_KEY = os.getenv("GOOGLE_SEARCH_KEY")
+SEARCH_PROVIDER = os.getenv("SEARCH_PROVIDER", "serper")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
 
 
 @register_tool("search", allow_overwrite=True)
@@ -86,18 +88,63 @@ class Search(BaseTool):
             return f"No results found for '{query}'. Try with a more general query, or remove the year filter."
 
 
+    def tavily_search(self, query: str):
+        from tavily import TavilyClient
+
+        client = TavilyClient(api_key=TAVILY_API_KEY)
+
+        for i in range(5):
+            try:
+                results = client.search(query=query, max_results=10, search_depth="basic")
+                break
+            except Exception as e:
+                print(e)
+                if i == 4:
+                    return f"Tavily search Timeout, return None, Please try again later."
+
+        try:
+            if not results.get("results"):
+                raise Exception(f"No results found for query: '{query}'. Use a less specific query.")
+
+            web_snippets = list()
+            idx = 0
+            for page in results["results"]:
+                idx += 1
+                date_published = ""
+                if page.get("published_date"):
+                    date_published = "\nDate published: " + page["published_date"]
+
+                snippet = ""
+                if page.get("content"):
+                    snippet = "\n" + page["content"]
+
+                redacted_version = f"{idx}. [{page['title']}]({page['url']}){date_published}\n{snippet}"
+
+                redacted_version = redacted_version.replace("Your browser can't play this video.", "")
+                web_snippets.append(redacted_version)
+
+            content = f"A Tavily search for '{query}' found {len(web_snippets)} results:\n\n## Web Results\n" + "\n\n".join(web_snippets)
+            return content
+        except:
+            return f"No results found for '{query}'. Try with a more general query, or remove the year filter."
+
     def call(self, params: Union[str, dict], **kwargs) -> str:
-        assert GOOGLE_SEARCH_KEY is not None, "Please set the GOOGLE_SEARCH_KEY environment variable."
+        if SEARCH_PROVIDER == "tavily":
+            assert TAVILY_API_KEY is not None, "Please set the TAVILY_API_KEY environment variable."
+        else:
+            assert GOOGLE_SEARCH_KEY is not None, "Please set the GOOGLE_SEARCH_KEY environment variable."
         try:
             query = params["query"]
         except:
             return "[Search] Invalid request format: Input must be a JSON object containing 'query' field"
-        
+
+        search_fn = self.tavily_search if SEARCH_PROVIDER == "tavily" else self.google_search
+
         if isinstance(query, str):
-            response = self.google_search(query)
+            response = search_fn(query)
         else:
             assert isinstance(query, List)
             with ThreadPoolExecutor(max_workers=3) as executor:
-                response = list(executor.map(self.google_search, query))
+                response = list(executor.map(search_fn, query))
             response = "\n=======\n".join(response)
         return response


### PR DESCRIPTION
## Search Provider Migration: `webagent-websailor`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

## Migration Summary — `webagent-websailor`

**Strategy**: ADDITIVE (Tavily added as parallel option; Serper fully preserved)

### Files Modified

**1. `WebAgent/WebSailor/src/tool_search.py`**
- Added `SEARCH_PROVIDER` env var (defaults to `"serper"`) and `TAVILY_API_KEY` env var at module level
- Added `tavily_search()` method to the `Search` class that:
  - Uses `TavilyClient` from the `tavily-python` SDK
  - Mirrors the same retry logic (5 attempts) as `google_search()`
  - Formats results into the identical numbered markdown snippet format (`idx. [title](url)\nsnippet`)
- Updated `call()` to route between `google_search` and `tavily_search` based on `SEARCH_PROVIDER` env var, with the correct API key assertion for each provider

**2. `WebAgent/WebSailor/requirements.txt`**
- Added `tavily-python` (existing `sglang[all]` and `qwen-agent[...]` preserved)

**3. `.env.example`** (repo root)
- Added `GOOGLE_SEARCH_KEY=your_key` (documents the env var WebSailor actually uses)
- Added `TAVILY_API_KEY=your_key` with link to https://app.tavily.com
- Added `SEARCH_PROVIDER=serper` with comment explaining the two options

### How to Use
Set `SEARCH_PROVIDER=tavily` and provide `TAVILY_API_KEY` to switch WebSailor to Tavily. The default (`serper`) preserves original behavior with no changes required.
