### PR TITLE
Add Tavily option for `webagent-webwatcher`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ MAX_WORKERS=30
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
 
+# Tavily API for web search (alternative to Serper)
+# Get your key from: https://app.tavily.com/
+TAVILY_API_KEY=your_key
+# Search provider: "serper" (default) or "tavily"
+SEARCH_PROVIDER=serper
+
 # Jina API for web page reading
 # Get your key from: https://jina.ai/
 JINA_API_KEYS=your_key

--- a/WebAgent/WebWatcher/infer/docker_env/requirements.txt
+++ b/WebAgent/WebWatcher/infer/docker_env/requirements.txt
@@ -82,6 +82,7 @@ frozenlist==1.7.0
 fsspec==2025.9.0
 gguf==0.17.1
 google-search-results=2.4.2
+tavily-python
 h11==0.16.0
 hf-xet==1.1.10
 httpcore==1.0.9

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/tools/private/nlp_web_search.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/tools/private/nlp_web_search.py
@@ -20,6 +20,8 @@ MAX_CHAR = int(os.getenv("MAX_CHAR", default=28000))
 SEARCH_ENGINE = os.getenv("SEARCH_ENGINE", "google")
 SEARCH_STRATEGY = os.getenv("SEARCH_STRATEGY", "rerank")
 TEXT_SEARCH_KEY = os.getenv("TEXT_SEARCH_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+SEARCH_PROVIDER = os.getenv("SEARCH_PROVIDER", "serper")
 
 # knowledge
 KNOWLEDGE_SNIPPET = """## 来自 {source} 的内容：
@@ -112,20 +114,61 @@ class WebSearch(BaseTool):
         except:
             return f"No results found for '{query}'. Try with a more general query, or remove the year filter."
 
+    def tavily_search(self, query: str):
+        from tavily import TavilyClient
+        client = TavilyClient(api_key=TAVILY_API_KEY)
+
+        for i in range(5):
+            try:
+                response = client.search(query=query, max_results=10, search_depth="basic")
+                break
+            except Exception as e:
+                print(e)
+                if i == 4:
+                    return f"Tavily search Timeout, return None, Please try again later."
+
+        try:
+            results = response.get("results", [])
+            if not results:
+                raise Exception(f"No results found for query: '{query}'. Use a less specific query.")
+
+            web_snippets = list()
+            for idx, page in enumerate(results, 1):
+                date_published = ""
+                if page.get("published_date"):
+                    date_published = "\nDate published: " + page["published_date"]
+
+                snippet = ""
+                if page.get("content"):
+                    snippet = "\n" + page["content"]
+
+                redacted_version = f"{idx}. [{page.get('title', '')}]({page['url']}){date_published}\n{snippet}"
+                redacted_version = redacted_version.replace("Your browser can't play this video.", "")
+                web_snippets.append(redacted_version)
+
+            content = f"A Tavily search for '{query}' found {len(web_snippets)} results:\n\n## Web Results\n" + "\n\n".join(web_snippets)
+            return content
+        except:
+            return f"No results found for '{query}'. Try with a more general query, or remove the year filter."
 
     def call(self, params: Union[str, dict], **kwargs) -> str:
-        assert TEXT_SEARCH_KEY is not None, "Please set the TEXT_SEARCH_KEY environment variable."
+        if SEARCH_PROVIDER == "tavily":
+            assert TAVILY_API_KEY is not None, "Please set the TAVILY_API_KEY environment variable."
+            search_fn = self.tavily_search
+        else:
+            assert TEXT_SEARCH_KEY is not None, "Please set the TEXT_SEARCH_KEY environment variable."
+            search_fn = self.google_search
         try:
             query = params["queries"][0]
         except:
             return "[Search] Invalid request format: Input must be a JSON object containing 'queries' field"
-        
+
         if isinstance(query, str):
-            response = self.google_search(query)
+            response = search_fn(query)
         else:
             assert isinstance(query, List)
             with ThreadPoolExecutor(max_workers=3) as executor:
-                response = list(executor.map(self.google_search, query))
+                response = list(executor.map(search_fn, query))
             response = "\n=======\n".join(response)
         return response
 


### PR DESCRIPTION
## Search Provider Migration: `webagent-webwatcher`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

## Migration Summary — `webagent-webwatcher`

**Strategy**: ADDITIVE (Tavily added as parallel option; Serper preserved as default)

### Files Modified

**1. `WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/tools/private/nlp_web_search.py`**
- Added `TAVILY_API_KEY` and `SEARCH_PROVIDER` env var reads at module level (lines 23–24)
- Added `tavily_search(query)` method (lines 117–152) that:
  - Uses `TavilyClient` from `tavily-python` (lazy import)
  - Retries up to 5 times on failure, matching `google_search` error handling
  - Normalizes Tavily results (`title`, `url`, `content`, `published_date`) to the same numbered snippet format as the existing Serper output
- Updated `call()` method (lines 154–173) to route via `SEARCH_PROVIDER`:
  - `"tavily"` → uses `tavily_search`, asserts `TAVILY_API_KEY` is set
  - Any other value (default `"serper"`) → uses `google_search`, asserts `TEXT_SEARCH_KEY` is set

**2. `WebAgent/WebWatcher/infer/docker_env/requirements.txt`**
- Added `tavily-python` (line 85) alongside the existing `google-search-results`

**3. `.env.example`**
- Added `TAVILY_API_KEY=your_key` with comment pointing to `https://app.tavily.com/`
- Added `SEARCH_PROVIDER=serper` (default) with comment listing `"serper"` and `"tavily"` as options

### Not Modified (per plan)
- `VLSearchImage` tool (image-based Google search) — out of scope, no Tavily equivalent
- `TEXT_SEARCH_KEY`, `google-search-results` dependency — retained (additive strategy)
