### PR TITLE
Add Tavily option for `webagent-webweaver`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,16 @@ MAX_WORKERS=30
 # API Keys and External Services
 # =============================================================================
 
+# Search provider selection: "serper" (default) or "tavily"
+SEARCH_PROVIDER=serper
+
 # Serper API for web search and Google Scholar
 # Get your key from: https://serper.dev/
 SERPER_KEY_ID=your_key
+
+# Tavily API for web search (used when SEARCH_PROVIDER=tavily)
+# Get your key from: https://app.tavily.com/
+TAVILY_API_KEY=your_key
 
 # Jina API for web page reading
 # Get your key from: https://jina.ai/

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,6 +159,7 @@ soxr==1.0.0
 starlette==0.47.3
 sympy==1.14.0
 tabulate==0.9.0
+tavily-python
 tenacity==9.1.2
 tiktoken==0.11.0
 tokenizers==0.22.0


### PR DESCRIPTION
## Search Provider Migration: `webagent-webweaver`

Adds Tavily as an additional option/parallel path while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

## Summary of Changes

### Strategy: ADDITIVE — Serper remains the default; Tavily added as a parallel option.

### Files Modified

**1. `WebAgent/WebWeaver/tool/tool_search.py`** — Main search tool
- Added `from tavily import TavilyClient` import
- Added `TAVILY_API_KEY` and `SEARCH_PROVIDER` env var reads (default: `'serper'`)
- Added `search_with_tavily(query)` method that mirrors the Serper method's structure:
  - Uses `TavilyClient.search()` with `max_results=10`
  - Same retry loop (5 attempts) as the Serper path
  - Formats results into the same markdown output format (`idx. [title](url)` with date/snippet)
- Added `_search(query)` routing method that dispatches to Tavily or Serper based on `SEARCH_PROVIDER`
- Updated `call()` to use `self._search()` instead of directly calling `self.search_with_serp()`

**2. `WebAgent/WebWeaver/tool/tool_search_and_visit.py`** — No changes needed
- Instantiates `Search()` with no args and calls `search_tool.call()` — provider routing happens transparently inside `Search._search()`

**3. `requirements.txt`** (root) — Added `tavily-python` dependency (alphabetical order, unpinned)

**4. `.env.example`** (root) — Added:
- `SEARCH_PROVIDER=serper` — switch to select provider (`serper` or `tavily`)
- `TAVILY_API_KEY=your_key` — with link to https://app.tavily.com/

### How to Use
Set `SEARCH_PROVIDER=tavily` and `TAVILY_API_KEY=tvly-...` in your environment to switch WebWeaver to Tavily search. The default remains Serper with no configuration changes needed.
