### PR TITLE
feat: add MiniMax as LLM provider with M3 as default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,10 +55,20 @@ SERPER_KEY_ID=your_key
 JINA_API_KEYS=your_key
 
 # Summary model API (OpenAI-compatible) for page summarization
+# You can use OpenAI, MiniMax, or any OpenAI-compatible provider
 # Get your key from: https://platform.openai.com/
 API_KEY=your_key
 API_BASE=your_api_base
 SUMMARY_MODEL_NAME=your_summary_model_name
+
+# MiniMax API for page summarization or as an LLM provider
+# Get your key from: https://platform.minimaxi.com/
+# Models: MiniMax-M2.5 (204K context), MiniMax-M2.5-highspeed (204K context)
+# To use MiniMax as the summary model, set:
+#   API_KEY=your_minimax_key
+#   API_BASE=https://api.minimax.io/v1
+#   SUMMARY_MODEL_NAME=MiniMax-M2.5
+MINIMAX_API_KEY=your_minimax_key
 
 # Dashscope API for file parsing (PDF, Office, etc.)
 # Get your key from: https://dashscope.aliyun.com/

--- a/.env.example
+++ b/.env.example
@@ -63,12 +63,12 @@ SUMMARY_MODEL_NAME=your_summary_model_name
 
 # MiniMax API for page summarization or as an LLM provider
 # Get your key from: https://platform.minimaxi.com/
-# Models: MiniMax-M2.7 (204K context, latest flagship), MiniMax-M2.7-highspeed (204K context),
-#         MiniMax-M2.5 (204K context), MiniMax-M2.5-highspeed (204K context)
+# Default model: MiniMax-M3 (512K context, 128K max output, supports image input, latest flagship)
+# Also supported: MiniMax-M2.7 (204K context, kept for backward compatibility)
 # To use MiniMax as the summary model, set:
 #   API_KEY=your_minimax_key
 #   API_BASE=https://api.minimax.io/v1
-#   SUMMARY_MODEL_NAME=MiniMax-M2.7
+#   SUMMARY_MODEL_NAME=MiniMax-M3
 MINIMAX_API_KEY=your_minimax_key
 
 # Dashscope API for file parsing (PDF, Office, etc.)

--- a/.env.example
+++ b/.env.example
@@ -63,11 +63,12 @@ SUMMARY_MODEL_NAME=your_summary_model_name
 
 # MiniMax API for page summarization or as an LLM provider
 # Get your key from: https://platform.minimaxi.com/
-# Models: MiniMax-M2.5 (204K context), MiniMax-M2.5-highspeed (204K context)
+# Models: MiniMax-M2.7 (204K context, latest flagship), MiniMax-M2.7-highspeed (204K context),
+#         MiniMax-M2.5 (204K context), MiniMax-M2.5-highspeed (204K context)
 # To use MiniMax as the summary model, set:
 #   API_KEY=your_minimax_key
 #   API_BASE=https://api.minimax.io/v1
-#   SUMMARY_MODEL_NAME=MiniMax-M2.5
+#   SUMMARY_MODEL_NAME=MiniMax-M2.7
 MINIMAX_API_KEY=your_minimax_key
 
 # Dashscope API for file parsing (PDF, Office, etc.)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Edit the `.env` file and provide your actual API keys and configuration values:
 
 - **SERPER_KEY_ID**: Get your key from [Serper.dev](https://serper.dev/) for web search and Google Scholar
 - **JINA_API_KEYS**: Get your key from [Jina.ai](https://jina.ai/) for web page reading
-- **API_KEY/API_BASE**: OpenAI-compatible API for page summarization from [OpenAI](https://platform.openai.com/)
+- **API_KEY/API_BASE**: OpenAI-compatible API for page summarization from [OpenAI](https://platform.openai.com/) or [MiniMax](https://platform.minimaxi.com/)
+- **MINIMAX_API_KEY**: (Optional) Get your key from [MiniMax](https://platform.minimaxi.com/) — can be used as the summary model (see [MiniMax Integration](#7-using-minimax-as-the-summary-model))
 - **DASHSCOPE_API_KEY**: Get your key from [Dashscope](https://dashscope.aliyun.com/) for file parsing
 - **SANDBOX_FUSION_ENDPOINT**: Python interpreter sandbox endpoints (see [SandboxFusion](https://github.com/bytedance/SandboxFusion))
 - **MODEL_PATH**: Path to your model weights
@@ -178,6 +179,49 @@ You need to modify the following in the file [inference/react_agent.py](https://
 - In the call_server function: Set the API key and URL to your OpenRouter account’s API and URL.
 - Change the model name to alibaba/tongyi-deepresearch-30b-a3b.
 - Adjust the content concatenation way as described in the comments on lines **88–90.**
+
+### 7. Using MiniMax as the Summary Model
+
+[MiniMax](https://platform.minimaxi.com/) provides OpenAI-compatible LLM APIs that can be used as the summary model for page summarization. MiniMax models (e.g., `MiniMax-M2.5`) offer 204K context length, which is well-suited for long document summarization tasks.
+
+**Option A: Set MiniMax as the summary model directly**
+
+In your `.env` file:
+
+```bash
+API_KEY=your_minimax_api_key
+API_BASE=https://api.minimax.io/v1
+SUMMARY_MODEL_NAME=MiniMax-M2.5
+```
+
+**Option B: Use MINIMAX_API_KEY as a fallback**
+
+If `API_KEY` is not set, the system will automatically fall back to using `MINIMAX_API_KEY` with MiniMax's API endpoint:
+
+```bash
+MINIMAX_API_KEY=your_minimax_api_key
+```
+
+**Using MiniMax in the qwen-agent framework**
+
+MiniMax is also registered as an LLM provider in the qwen-agent framework. You can use it by specifying `model_type: 'minimax'` or by using a model name containing "minimax":
+
+```python
+from qwen_agent.llm import get_chat_model
+
+# Auto-detected by model name
+llm = get_chat_model({'model': 'MiniMax-M2.5'})
+
+# Or explicitly specify the provider
+llm = get_chat_model({
+    'model': 'MiniMax-M2.5',
+    'model_type': 'minimax',
+    'generate_cfg': {
+        'temperature': 0.7,
+        'max_tokens': 4096,
+    }
+})
+```
 
 ## Benchmark Evaluation
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You need to modify the following in the file [inference/react_agent.py](https://
 
 ### 7. Using MiniMax as the Summary Model
 
-[MiniMax](https://platform.minimaxi.com/) provides OpenAI-compatible LLM APIs that can be used as the summary model for page summarization. MiniMax models (e.g., `MiniMax-M2.5`) offer 204K context length, which is well-suited for long document summarization tasks.
+[MiniMax](https://platform.minimaxi.com/) provides OpenAI-compatible LLM APIs that can be used as the summary model for page summarization. MiniMax models (e.g., `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) offer 204K context length and enhanced reasoning and coding capabilities, which are well-suited for long document summarization tasks.
 
 **Option A: Set MiniMax as the summary model directly**
 
@@ -191,7 +191,7 @@ In your `.env` file:
 ```bash
 API_KEY=your_minimax_api_key
 API_BASE=https://api.minimax.io/v1
-SUMMARY_MODEL_NAME=MiniMax-M2.5
+SUMMARY_MODEL_NAME=MiniMax-M2.7
 ```
 
 **Option B: Use MINIMAX_API_KEY as a fallback**
@@ -210,11 +210,11 @@ MiniMax is also registered as an LLM provider in the qwen-agent framework. You c
 from qwen_agent.llm import get_chat_model
 
 # Auto-detected by model name
-llm = get_chat_model({'model': 'MiniMax-M2.5'})
+llm = get_chat_model({'model': 'MiniMax-M2.7'})
 
 # Or explicitly specify the provider
 llm = get_chat_model({
-    'model': 'MiniMax-M2.5',
+    'model': 'MiniMax-M2.7',
     'model_type': 'minimax',
     'generate_cfg': {
         'temperature': 0.7,

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You need to modify the following in the file [inference/react_agent.py](https://
 
 ### 7. Using MiniMax as the Summary Model
 
-[MiniMax](https://platform.minimaxi.com/) provides OpenAI-compatible LLM APIs that can be used as the summary model for page summarization. MiniMax models (e.g., `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) offer 204K context length and enhanced reasoning and coding capabilities, which are well-suited for long document summarization tasks.
+[MiniMax](https://platform.minimaxi.com/) provides OpenAI-compatible LLM APIs that can be used as the summary model for page summarization. The default model is `MiniMax-M3` (512K context length, 128K max output, supports image input, latest flagship). `MiniMax-M2.7` is also supported for backward compatibility.
 
 **Option A: Set MiniMax as the summary model directly**
 
@@ -191,12 +191,12 @@ In your `.env` file:
 ```bash
 API_KEY=your_minimax_api_key
 API_BASE=https://api.minimax.io/v1
-SUMMARY_MODEL_NAME=MiniMax-M2.7
+SUMMARY_MODEL_NAME=MiniMax-M3
 ```
 
 **Option B: Use MINIMAX_API_KEY as a fallback**
 
-If `API_KEY` is not set, the system will automatically fall back to using `MINIMAX_API_KEY` with MiniMax's API endpoint:
+If `API_KEY` is not set, the system will automatically fall back to using `MINIMAX_API_KEY` with MiniMax's API endpoint and `MiniMax-M3` as the default model:
 
 ```bash
 MINIMAX_API_KEY=your_minimax_api_key
@@ -210,11 +210,11 @@ MiniMax is also registered as an LLM provider in the qwen-agent framework. You c
 from qwen_agent.llm import get_chat_model
 
 # Auto-detected by model name
-llm = get_chat_model({'model': 'MiniMax-M2.7'})
+llm = get_chat_model({'model': 'MiniMax-M3'})
 
 # Or explicitly specify the provider
 llm = get_chat_model({
-    'model': 'MiniMax-M2.7',
+    'model': 'MiniMax-M3',
     'model_type': 'minimax',
     'generate_cfg': {
         'temperature': 0.7,

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/__init__.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/__init__.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from .azure import TextChatAtAzure
 from .base import LLM_REGISTRY, BaseChatModel, ModelServiceError
+from .minimax import TextChatAtMiniMax
 from .oai import TextChatAtOAI
 from .openvino import OpenVINO
 from .qwen_dashscope import QwenChatAtDS
@@ -64,6 +65,10 @@ def get_chat_model(cfg: Union[dict, str] = 'qwen-plus') -> BaseChatModel:
 
     model = cfg.get('model', '')
 
+    if 'minimax' in model.lower():
+        model_type = 'minimax'
+        return LLM_REGISTRY[model_type](cfg)
+
     if '-vl' in model.lower():
         model_type = 'qwenvl_dashscope'
         return LLM_REGISTRY[model_type](cfg)
@@ -84,6 +89,7 @@ __all__ = [
     'QwenChatAtDS',
     'TextChatAtOAI',
     'TextChatAtAzure',
+    'TextChatAtMiniMax',
     'QwenVLChatAtDS',
     'QwenVLChatAtOAI',
     'QwenAudioChatAtDS',

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
@@ -1,0 +1,58 @@
+import copy
+import os
+from typing import Dict, Optional
+
+from qwen_agent.llm.base import register_llm
+from qwen_agent.llm.oai import TextChatAtOAI
+
+MINIMAX_DEFAULT_API_BASE = 'https://api.minimax.io/v1'
+
+
+@register_llm('minimax')
+class TextChatAtMiniMax(TextChatAtOAI):
+    """LLM provider for MiniMax (OpenAI-compatible API).
+
+    MiniMax provides large language models accessible via an OpenAI-compatible
+    API. Supported models include MiniMax-M2.5 and MiniMax-M2.5-highspeed,
+    both offering 204K context length.
+
+    Configuration example::
+
+        llm_cfg = {
+            'model': 'MiniMax-M2.5',
+            'model_type': 'minimax',
+            'generate_cfg': {
+                'temperature': 0.7,
+                'max_tokens': 4096,
+            }
+        }
+
+    Environment variables:
+        MINIMAX_API_KEY: Your MiniMax API key (required).
+    """
+
+    def __init__(self, cfg: Optional[Dict] = None):
+        cfg = copy.deepcopy(cfg) or {}
+
+        # Set MiniMax defaults before calling parent __init__
+        if not cfg.get('model'):
+            cfg['model'] = 'MiniMax-M2.5'
+
+        # Use MiniMax API base URL if no custom server is specified
+        if not cfg.get('api_base') and not cfg.get('base_url') and not cfg.get('model_server'):
+            cfg['model_server'] = MINIMAX_DEFAULT_API_BASE
+
+        # Use MINIMAX_API_KEY env var, fall back to OPENAI_API_KEY
+        if not cfg.get('api_key'):
+            api_key = os.getenv('MINIMAX_API_KEY') or os.getenv('OPENAI_API_KEY')
+            if api_key:
+                cfg['api_key'] = api_key
+
+        # MiniMax requires temperature > 0
+        generate_cfg = cfg.get('generate_cfg', {})
+        temp = generate_cfg.get('temperature', None)
+        if temp is not None and temp <= 0:
+            generate_cfg['temperature'] = 0.01
+            cfg['generate_cfg'] = generate_cfg
+
+        super().__init__(cfg)

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
@@ -13,13 +13,14 @@ class TextChatAtMiniMax(TextChatAtOAI):
     """LLM provider for MiniMax (OpenAI-compatible API).
 
     MiniMax provides large language models accessible via an OpenAI-compatible
-    API. Supported models include MiniMax-M2.5 and MiniMax-M2.5-highspeed,
-    both offering 204K context length.
+    API. Supported models include MiniMax-M2.7 and MiniMax-M2.7-highspeed
+    (latest flagship with enhanced reasoning and coding), as well as
+    MiniMax-M2.5 and MiniMax-M2.5-highspeed, all offering 204K context length.
 
     Configuration example::
 
         llm_cfg = {
-            'model': 'MiniMax-M2.5',
+            'model': 'MiniMax-M2.7',
             'model_type': 'minimax',
             'generate_cfg': {
                 'temperature': 0.7,
@@ -36,7 +37,7 @@ class TextChatAtMiniMax(TextChatAtOAI):
 
         # Set MiniMax defaults before calling parent __init__
         if not cfg.get('model'):
-            cfg['model'] = 'MiniMax-M2.5'
+            cfg['model'] = 'MiniMax-M2.7'
 
         # Use MiniMax API base URL if no custom server is specified
         if not cfg.get('api_base') and not cfg.get('base_url') and not cfg.get('model_server'):

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/llm/minimax.py
@@ -13,14 +13,14 @@ class TextChatAtMiniMax(TextChatAtOAI):
     """LLM provider for MiniMax (OpenAI-compatible API).
 
     MiniMax provides large language models accessible via an OpenAI-compatible
-    API. Supported models include MiniMax-M2.7 and MiniMax-M2.7-highspeed
-    (latest flagship with enhanced reasoning and coding), as well as
-    MiniMax-M2.5 and MiniMax-M2.5-highspeed, all offering 204K context length.
+    API. The default model is ``MiniMax-M3`` (latest flagship with 512K context
+    length, 128K max output, and support for image inputs). ``MiniMax-M2.7``
+    is also supported for backward compatibility.
 
     Configuration example::
 
         llm_cfg = {
-            'model': 'MiniMax-M2.7',
+            'model': 'MiniMax-M3',
             'model_type': 'minimax',
             'generate_cfg': {
                 'temperature': 0.7,
@@ -37,7 +37,7 @@ class TextChatAtMiniMax(TextChatAtOAI):
 
         # Set MiniMax defaults before calling parent __init__
         if not cfg.get('model'):
-            cfg['model'] = 'MiniMax-M2.7'
+            cfg['model'] = 'MiniMax-M3'
 
         # Use MiniMax API base URL if no custom server is specified
         if not cfg.get('api_base') and not cfg.get('base_url') and not cfg.get('model_server'):

--- a/inference/tool_visit.py
+++ b/inference/tool_visit.py
@@ -97,9 +97,13 @@ class Visit(BaseTool):
         return response.strip()
         
     def call_server(self, msgs, max_retries=2):
-        api_key = os.environ.get("API_KEY")
-        url_llm = os.environ.get("API_BASE")
-        model_name = os.environ.get("SUMMARY_MODEL_NAME", "")
+        api_key = os.environ.get("API_KEY") or os.environ.get("MINIMAX_API_KEY")
+        url_llm = os.environ.get("API_BASE") or (
+            "https://api.minimax.io/v1" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else None
+        )
+        model_name = os.environ.get("SUMMARY_MODEL_NAME") or (
+            "MiniMax-M2.5" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else ""
+        )
         client = OpenAI(
             api_key=api_key,
             base_url=url_llm,

--- a/inference/tool_visit.py
+++ b/inference/tool_visit.py
@@ -102,7 +102,7 @@ class Visit(BaseTool):
             "https://api.minimax.io/v1" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else None
         )
         model_name = os.environ.get("SUMMARY_MODEL_NAME") or (
-            "MiniMax-M2.5" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else ""
+            "MiniMax-M2.7" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else ""
         )
         client = OpenAI(
             api_key=api_key,

--- a/inference/tool_visit.py
+++ b/inference/tool_visit.py
@@ -102,7 +102,7 @@ class Visit(BaseTool):
             "https://api.minimax.io/v1" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else None
         )
         model_name = os.environ.get("SUMMARY_MODEL_NAME") or (
-            "MiniMax-M2.7" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else ""
+            "MiniMax-M3" if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("API_KEY") else ""
         )
         client = OpenAI(
             api_key=api_key,


### PR DESCRIPTION
## Summary
Add MiniMax as an LLM provider for the summary model and qwen-agent framework, with the latest MiniMax-M3 as the default model. MiniMax-M2.7 is preserved for backward compatibility; earlier M2.5 / M2.5-highspeed entries have been removed.

## Changes
- Add MiniMax LLM provider (`TextChatAtMiniMax`) in the qwen-agent framework with auto-detection by model name
- Default model upgraded to **MiniMax-M3** (512K context, 128K max output, image input supported, latest flagship); **MiniMax-M2.7** kept for backward compatibility
- Add `MINIMAX_API_KEY` fallback in `tool_visit.py` for page summarization (default fallback model: `MiniMax-M3`)
- Update `.env.example` with MiniMax configuration
- Document MiniMax integration in README

## Why
MiniMax-M3 is the latest flagship model with 512K context length and 128K max output, well-suited for long document summarization tasks. Existing users of MiniMax-M2.7 remain supported without code changes.

## Testing
- Python syntax validation passed for all modified files
- MiniMax provider inherits from `TextChatAtOAI` (OpenAI-compatible), minimal risk
- Verified: `MiniMax-M3` is the default model in `minimax.py` and `tool_visit.py`; `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` references removed