### PR TITLE
fix: skip temperature param for OpenAI reasoning/newer models in summary tool

### DIFF
--- a/WebAgent/WebResummer/src/tool_visit.py
+++ b/WebAgent/WebResummer/src/tool_visit.py
@@ -86,13 +86,15 @@ class Visit(BaseTool):
             api_key=SUMMARY_API_KEY,
             base_url=SUMMARY_URL,
         )
+        # Reasoning models (o1, o3, o4) and some newer models (e.g. gpt-5) do not support
+        # the temperature parameter; skip it for those model families.
+        _NO_TEMPERATURE_PREFIXES = ("o1", "o3", "o4", "gpt-5")
         for attempt in range(max_retries):
             try:
-                chat_response = client.chat.completions.create(
-                    model=SUMMARY_MODEL_NAME,
-                    messages=msgs,
-                    temperature=0.7
-                )
+                create_kwargs = dict(model=SUMMARY_MODEL_NAME, messages=msgs)
+                if not any(SUMMARY_MODEL_NAME.startswith(p) for p in _NO_TEMPERATURE_PREFIXES):
+                    create_kwargs["temperature"] = 0.7
+                chat_response = client.chat.completions.create(**create_kwargs)
                 content = chat_response.choices[0].message.content
                 print(content)
                 if content:

--- a/inference/tool_visit.py
+++ b/inference/tool_visit.py
@@ -104,13 +104,15 @@ class Visit(BaseTool):
             api_key=api_key,
             base_url=url_llm,
         )
+        # Reasoning models (o1, o3, o4) and some newer models (e.g. gpt-5) do not support
+        # the temperature parameter; skip it for those model families.
+        _NO_TEMPERATURE_PREFIXES = ("o1", "o3", "o4", "gpt-5")
         for attempt in range(max_retries):
             try:
-                chat_response = client.chat.completions.create(
-                    model=model_name,
-                    messages=msgs,
-                    temperature=0.7
-                )
+                create_kwargs = dict(model=model_name, messages=msgs)
+                if not any(model_name.startswith(p) for p in _NO_TEMPERATURE_PREFIXES):
+                    create_kwargs["temperature"] = 0.7
+                chat_response = client.chat.completions.create(**create_kwargs)
                 content = chat_response.choices[0].message.content
                 if content:
                     try:


### PR DESCRIPTION
Fixes #211

## Problem

When using newer OpenAI models (o1, o3, o4 reasoning models, gpt-5, etc.) as the summary model (`SUMMARY_MODEL_NAME`), the `call_server` method in both `inference/tool_visit.py` and `WebAgent/WebResummer/src/tool_visit.py` unconditionally passes `temperature=0.7`. These model families do not support the `temperature` parameter and will return an API error.

## Solution

Before building the API call kwargs, check whether the model name starts with a prefix known to not support temperature (`o1`, `o3`, `o4`, `gpt-5`). Only include `temperature` in the request when the model supports it.

```python
_NO_TEMPERATURE_PREFIXES = ("o1", "o3", "o4", "gpt-5")
create_kwargs = dict(model=model_name, messages=msgs)
if not any(model_name.startswith(p) for p in _NO_TEMPERATURE_PREFIXES):
    create_kwargs["temperature"] = 0.7
chat_response = client.chat.completions.create(**create_kwargs)
```

## Files changed

- `inference/tool_visit.py` — `Visit.call_server()`
- `WebAgent/WebResummer/src/tool_visit.py` — `Visit.call_server()`

## Testing

Tested locally by setting `SUMMARY_MODEL_NAME=o1-mini` and verifying no `temperature` is passed; and with `SUMMARY_MODEL_NAME=gpt-4o` to confirm `temperature=0.7` is still included for standard models.