### PR TITLE
fix: correct pip install order so VLSearchImage is registered (fixes #234)

### DIFF
--- a/WebAgent/WebWatcher/infer/scripts_eval/scripts/eval.sh
+++ b/WebAgent/WebWatcher/infer/scripts_eval/scripts/eval.sh
@@ -115,9 +115,8 @@ else
 fi
 
 
-pip uninstall qwen-agent
-pip install -e vl_search_r1/qwen-agent-o1_search --no-deps
 pip install "qwen-agent[code_interpreter]"
+pip install -e vl_search_r1/qwen-agent-o1_search --no-deps
 
 
 # for i in 1 2 3


### PR DESCRIPTION
Fixes #234

## Problem

The `eval.sh` script installs packages in the wrong order, causing `VLSearchImage` to be absent from `TOOL_REGISTRY` when `agent_eval.py` runs:

```bash
# OLD (broken) order
pip uninstall qwen-agent
pip install -e vl_search_r1/qwen-agent-o1_search --no-deps   # installs local fork with VLSearchImage
pip install "qwen-agent[code_interpreter]"                     # ← overwrites local fork with PyPI version!
```

Because `pip install "qwen-agent[code_interpreter]"` replaces the editable local install, `VLSearchImage` is no longer in `TOOL_REGISTRY`. When `Qwen_agent` is then instantiated with `function_list=['web_search', 'VLSearchImage', 'visit', 'code_interpreter']`, qwen-agent raises:

```
ValueError: Tool VLSearchImage is not registered.
```

## Solution

Reverse the install order so the local fork (which adds `VLSearchImage`) is installed **after** the PyPI package has already pulled in all dependencies:

```bash
# NEW (correct) order
pip install "qwen-agent[code_interpreter]"                     # pulls in all deps first
pip install -e vl_search_r1/qwen-agent-o1_search --no-deps   # overrides with local fork; VLSearchImage stays registered
```

The `pip uninstall qwen-agent` step is also removed as it is unnecessary — `pip install` already replaces an existing installation.

## Testing

Verified the `eval.sh` diff is minimal (3-line change) and that the install sequence now ends with the local fork active, ensuring `VLSearchImage` is in `TOOL_REGISTRY` when `agent_eval.py` initialises `Qwen_agent`.