### PR TITLE
fix: guard against IndexError/AttributeError on empty LLM choices (19 sites)

### DIFF
--- a/WebAgent/AgentFold/infer.py
+++ b/WebAgent/AgentFold/infer.py
@@ -112,6 +112,8 @@ def get_llm_response_nonstream(prompt, check_func_list=[]):
         presence_penalty=1.1
     )
 
+    if not response.choices:
+        raise ValueError("LLM returned empty choices")
     return response.choices[0].text
 
 def execute_tool(llm_generated_response):

--- a/WebAgent/WebDancer/demos/tools/private/visit.py
+++ b/WebAgent/WebDancer/demos/tools/private/visit.py
@@ -124,6 +124,8 @@ class Visit(BaseTool):
                 messages=messages,
                 response_format={"type": "json_object"},
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             return response.choices[0].message.content
         return ""
 

--- a/WebAgent/WebResummer/src/react_agent.py
+++ b/WebAgent/WebResummer/src/react_agent.py
@@ -59,6 +59,8 @@ class MultiTurnReactAgent(FnCallAgent):
                     temperature=self.llm_generate_cfg.get('temperature', 0.6),
                     top_p=self.llm_generate_cfg.get('top_p', 0.95),
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     return content

--- a/WebAgent/WebResummer/src/tool_visit.py
+++ b/WebAgent/WebResummer/src/tool_visit.py
@@ -93,6 +93,8 @@ class Visit(BaseTool):
                     messages=msgs,
                     temperature=0.7
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 print(content)
                 if content:

--- a/WebAgent/WebSailor/src/evaluate.py
+++ b/WebAgent/WebSailor/src/evaluate.py
@@ -42,6 +42,8 @@ def call_llm_judge(item):
                                     model='qwen2.5-72b-instruct',
                                     messages=[{"role": "user", "content": prompt}],
                 )    
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 response = chat_response.choices[0].message.content
                 if response:
                     break

--- a/WebAgent/WebSailor/src/react_agent.py
+++ b/WebAgent/WebSailor/src/react_agent.py
@@ -55,6 +55,8 @@ class MultiTurnReactAgent(FnCallAgent):
                     temperature=self.llm_generate_cfg.get('temperature', 0.6),
                     top_p=self.llm_generate_cfg.get('top_p', 0.95),
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     return content

--- a/WebAgent/WebSailor/src/tool_visit.py
+++ b/WebAgent/WebSailor/src/tool_visit.py
@@ -83,6 +83,8 @@ class Visit(BaseTool):
                     stop=["\n<tool_response>", "<tool_response>"],
                     temperature=0.7
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     try:

--- a/WebAgent/WebWalker/src/agent.py
+++ b/WebAgent/WebWalker/src/agent.py
@@ -58,6 +58,8 @@ class WebWalker(FnCallAgent):
                     response_format={"type": "json_object"},
                     messages=messages
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 print(response.choices[0].message.content)
                 # response_content = json.loads(response.choices[0].message.content)
                 if "true" in response.choices[0].message.content:
@@ -93,6 +95,8 @@ class WebWalker(FnCallAgent):
                     response_format={"type": "json_object"},
                     messages=messages
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 print(response.choices[0].message.content)
                 if "true" in response.choices[0].message.content:
                     try:

--- a/WebAgent/WebWalker/src/rag_system.py
+++ b/WebAgent/WebWalker/src/rag_system.py
@@ -161,6 +161,8 @@ def doubao_api(ds, output_path):
                     {"role": "user", "content": data["question"]}
                 ]
             )
+            if not completion.choices or completion.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             return completion.choices[0].message.content
         except Exception as e:
             print(f"Error: {e}")
@@ -210,6 +212,8 @@ def kimi_api(ds, output_path):
                     "function": {"name": "$web_search"}
                 }]
             )
+            if not completion.choices:
+                raise ValueError("LLM returned empty choices")
             return completion.choices[0]
         except Exception as e:
             print(f"Error: {e}")

--- a/WebAgent/WebWatcher/infer/scripts_eval/agent_eval.py
+++ b/WebAgent/WebWatcher/infer/scripts_eval/agent_eval.py
@@ -228,6 +228,8 @@ class OmniSearch:
                         top_p=0.95,
                         temperature=0.6
                     )
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_content = response.choices[0].message.content
                     # break
                     if response_content:

--- a/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/tools/private/visit.py
+++ b/WebAgent/WebWatcher/infer/vl_search_r1/qwen-agent-o1_search/qwen_agent/tools/private/visit.py
@@ -102,6 +102,8 @@ class Visit(BaseTool):
                     stop=["\n<tool_response>", "<tool_response>"],
                     temperature=0.7
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     try:

--- a/WebAgent/WebWeaver/react_agent_outline_write.py
+++ b/WebAgent/WebWeaver/react_agent_outline_write.py
@@ -58,6 +58,8 @@ class MultiTurnReactAgentWrite(FnCallAgent):
                     temperature=self.llm_generate_cfg.get('temperature', 0.6),	
                     top_p=self.llm_generate_cfg.get('top_p', 0.95),	
                 )	
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content	
                 if content:	
                     return content	

--- a/WebAgent/WebWeaver/react_agent_search_id.py
+++ b/WebAgent/WebWeaver/react_agent_search_id.py
@@ -64,6 +64,8 @@ class MultiTurnReactAgentSearch(FnCallAgent):
                     temperature=self.llm_generate_cfg.get('temperature', 0.6),
                     top_p=self.llm_generate_cfg.get('top_p', 0.95),
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     return content

--- a/WebAgent/WebWeaver/tool/tool_retrieve.py
+++ b/WebAgent/WebWeaver/tool/tool_retrieve.py
@@ -185,6 +185,8 @@ class Retrieve(BaseTool):
                     messages=msgs,
                     temperature=0.7
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     try:

--- a/inference/file_tools/video_analysis.py
+++ b/inference/file_tools/video_analysis.py
@@ -588,6 +588,8 @@ class VideoAnalysis(BaseTool):
                 messages=messages,
                 temperature=0.3,
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             return response.choices[0].message.content
         except Exception as e:
             logger.error(f"AI analysis failed: {str(e)}")

--- a/inference/react_agent.py
+++ b/inference/react_agent.py
@@ -81,6 +81,8 @@ class MultiTurnReactAgent(FnCallAgent):
                     max_tokens=10000,
                     presence_penalty=self.llm_generate_cfg.get('presence_penalty', 1.1)
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
 
                 # OpenRouter provides API calling. If you want to use OpenRouter, you need to uncomment line 89 - 90.

--- a/inference/tool_visit.py
+++ b/inference/tool_visit.py
@@ -111,6 +111,8 @@ class Visit(BaseTool):
                     messages=msgs,
                     temperature=0.7
                 )
+                if not chat_response.choices or chat_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 content = chat_response.choices[0].message.content
                 if content:
                     try:


### PR DESCRIPTION
LLM APIs (OpenAI-compatible) can return HTTP 200 with an empty choices list or choices[0].message=None — SDK does NOT raise. 17 files, 19 guard sites. Found by pact static analysis.