### PR TITLE
fix(ParallelMuse): repair stale call sites that crash compressed_reasoning_aggregation

### DIFF
--- a/WebAgent/ParallelMuse/compressed_reasoning_aggregation.py
+++ b/WebAgent/ParallelMuse/compressed_reasoning_aggregation.py
@@ -172,7 +172,7 @@ async def call_state_report(sem, traj, max_retries=10):
                     {'role': 'user', 'content': user_input}
                 ]
 
-                response = await get_llm_response(messages, max_tokens, data_path)
+                response = await get_llm_response(messages, max_tokens)
                 response = response.split('</think>')[-1].strip()
                 if "Error getting visit response" in response:
                     raise Exception(response)
@@ -225,7 +225,7 @@ async def call_info_integrate(sem, question, report_group, max_retries=10):
                 response = None
 
     if response is None:
-        return "[Error getting integrated answer]"
+        return 0, "[Error getting integrated answer]"
 
     final_answer = response.split("<answer>")[-1].split("</answer>")[0].strip()
     print(f"Obtained Integrated Answer: {final_answer}")
@@ -270,7 +270,7 @@ async def main():
             if 'prediction' in traj.keys() and traj['prediction'] != '[No Prediction]':
                 filtered_cluster.append(traj)
     
-        tasks.append(call_converge(sem, filtered_cluster, data_path))
+        tasks.append(call_converge(sem, filtered_cluster))
 
     results = []
 


### PR DESCRIPTION
## Problem

`WebAgent/ParallelMuse/compressed_reasoning_aggregation.py` has three stale call sites left over from a refactor that removed `data_path` threading. They break the script's only entry point (`main()` → `asyncio.run(main())`), and each is provably wrong against the function's own definition (and, for `get_llm_response`, against the correct sibling call in the same file).

**1. `call_converge` — wrong argument count (crashes `main()` on launch)**

```python
async def call_converge(sem, traj_group):          # line 236 — 2 params
...
tasks.append(call_converge(sem, filtered_cluster, data_path))   # line 273 — 3 args
```

`call_converge` is `async`, so the extra argument raises immediately when the coroutine object is created — the loop aborts on the first cluster.

**2. `get_llm_response` — wrong argument count + undefined name**

```python
async def get_llm_response(messages, max_tokens):  # line 75 — 2 params
...
response = await get_llm_response(messages, max_tokens, data_path)   # line 175 — 3 args
...
response = await get_llm_response(messages, max_tokens)              # line 215 — correct
```

`data_path` isn't a parameter of `call_state_report` and isn't a module global, so line 175 hits `NameError` (and a 3-arg/2-param `TypeError`). Line 215 shows the intended 2-arg form.

**3. `call_info_integrate` — inconsistent return type**

```python
if response is None:
    return "[Error getting integrated answer]"     # line 228 — bare str
...
return 0, "[No Valid Answer]"                        # 2-tuple
return len(report_group), final_answer               # 2-tuple
```

The caller unpacks two values — `merge_num, prediction = await call_info_integrate(...)` — so the bare-string error path raises `ValueError: too many values to unpack (expected 2)` whenever the integrate LLM call fails.

## Fix

```python
tasks.append(call_converge(sem, filtered_cluster))                 # line 273
response = await get_llm_response(messages, max_tokens)            # line 175
return 0, "[Error getting integrated answer]"                      # line 228
```

## Verification

- AST check on the file confirms every `call_converge` / `get_llm_response` call now matches its 2-parameter definition, and all three `call_info_integrate` returns are 2-tuples.
- `python -m py_compile` passes.
- A standalone repro reproduces the three failures on the current code (`TypeError` / `NameError` / `ValueError`) and confirms the corrected calls succeed.

The full pipeline needs an LLM server (`REPORT_CONVERGE_BASE_URL_POOL`) and a rollout file, so I couldn't run it end-to-end — but these three defects are argument-count / return-type errors that are unambiguous against the file's own definitions and its own correct sibling call, and they sit on the script's only code path.
